### PR TITLE
Add multi-state-buttons and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,10 @@
-##################################################################
-Jquery addon for creating toggle buttons for radios and checkboxes
-##################################################################
+##############################################################################################
+Jquery addon for creating multi-state- and toggle buttons for radios, checkboxes and dropdowns
+##############################################################################################
 
-Simple javascript file to help toggle bootstrap glyphs on toggle buttons.
-Library adds two methdos for jquery for easy usage.
+Simple javascript file to help toggle bootstrap glyphs on toggle buttons
+and replace checkboxes, radio groups and dropdowns with multi-state-buttons.
+Library adds four methods for jquery for easy usage.
 This script requires `jquery <https://jquery.com/>`_ (3.1+).
 
 Usage
@@ -29,6 +30,8 @@ You can add js handlers for :code:`button` with following snippet:
     officon: 'unchecked',
   });
 
+Supported in versions later than 1.0.0 by calling method ::code:`makeMultiStateButton`.
+
 Check the script for more details.
 
 replaceCheckboxesWithButtons
@@ -49,10 +52,101 @@ You can convert :code:`ul` with radio inputs or checkboxes to group of buttons w
 
   $('#options').replaceCheckboxesWithButtons();
 
+In version 1.0.0, radio buttons were converted to toggle buttons (one button per
+each option), but in later versions, radio buttons are converted to
+multi-state-buttons (one button per radio group).
+
+Supported in versions later than 1.0.0 by calling method
+::code:`replaceInputsWithMultiStateButtons`.
+
 Check the script for more details.
 
-Inegration to frameworks
-========================
+makeMultiStateButton
+--------------------
+
+You can add js handlers for :code:`button` with following snippet:
+
+.. code-block:: html
+
+  <button class="mltsb-3-stage">Click to change state</button>
+
+.. code-block:: javascript
+
+  $('button.mltsb-3-stage').makeMultiIconButton({
+    num_of_states: 3,
+		text_0: 'Option 0',
+		text_1: 'Option 1',
+		text_2: 'Option 2',
+  })
+
+Check the script for more details.
+
+replaceInputsWithMultiStateButtons
+----------------------------------
+
+You can convert dropdowns to multi-state-buttons with the following code:
+
+.. code-block:: html
+
+  <label for="dropdowns_1">Buttons:</label>
+  <p id="dropdowns_1">
+    <select>
+      <option value="">Default</option>
+      <option value="a">Option A</option>
+      <option value="b">Option B</option>
+    </select>
+    <select>
+      <option value="">Default</option>
+      <option value="c">Option C</option>
+    </select>
+  </p>
+  <label for="dropdowns_2">Different group of buttons:</label>
+  <p id="dropdowns_2">
+    <select>
+      <option value="">Default</option>
+      <option value="d">Option D</option>
+      <option value="e">Option E</option>
+    </select>
+  </p>
+
+.. code-block:: javascript
+
+  $('#dropdowns_1, #dropdowns_2').replaceInputsWithMultiStateButtons();
+
+You can convert checkboxes and radio groups to multi-state buttons with the
+following code:
+
+.. code-block:: html
+
+  <label for="cbAndRadio">Checkboxes and radio buttons:</label><br>
+  <ul id="cbAndRadio">
+    <li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+    <li><label><input name="rg1" type="radio" value="0" checked> State 0</label></li>
+    <li><label><input name="rg1" type="radio" value="1"> State 1</label></li>
+    <li><label><input name="rg1" type="radio" value="2"> State 2</label></li>
+    <li><label><input name="options" type="checkbox" value="2"> Option 2</label></li>
+    <li><label><input name="rg2" type="radio" value="0"> State 0</label></li>
+    <li><label><input name="rg2" type="radio" value="1" checked> State 1</label></li>
+    <li><label><input name="rg2" type="radio" value="2"> State 2</label></li>
+  </ul>
+
+.. code-block:: javascript
+
+  $('#cbAndRadio').replaceInputsWithMultiStateButtons();
+
+Multi-state-buttons can either be single-icon-buttons (displays a single icon
+on the button at all times) or multi-icon-buttons (displays an icon for each of
+the states on the button at all times, allowing the icon of the current state to
+be different in some way).
+By default, buttons with three or less states are single-icon-buttons and ones
+with four or more states are multi-state-buttons.
+
+More details can be found in the
+`instruction file <multi_state_button_instructions.rst>`_.
+
+
+Integration to frameworks
+=========================
 
 There is integration to following frameworks:
 

--- a/examples.html
+++ b/examples.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Examples</title>
+	<link rel="stylesheet" href="https://code.jquery.com/ui/1.12.0/themes/base/jquery-ui.css" integrity="sha384-HaPjwh4bVGBOgzg3JW0bTImgRwwoEE+XgYBOiIaAd6EFqpC4wQz9AyxDD5I0ySve" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+	<script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
+	<script src="jquery-toggle.js"></script>
+</head>
+
+<body>
+
+	<h1>Toggle buttons</h1>
+
+	<h4>Example 1: makeToggleButton</h4>
+
+	<button class="toggle">Toggle me</button>
+
+	<script>
+		$('button.toggle').makeToggleButton({
+			// onicon: 'check', // bootstrap glyph names
+			oncolor: 'success', // bootstrap classes
+			// officon: 'unchecked',
+		});
+	</script>
+	<br><br>
+
+
+	<h4>Example 2: replaceCheckboxesWithButtons</h4>
+
+	<label for="ex2">From checkboxes and radio buttons:</label><br>
+	<ul id="ex2" autocomplete="off">
+		<li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+		<li><label><input name="options" type="checkbox" value="1"
+			data-off-icon="remove" data-off-color="danger" data-on-text="Include"> Option 1</label></li>
+		<li><label><input name="rg2_1" type="radio" value="0" checked> Two states</label></li>
+		<li><label><input name="rg2_1" type="radio" value="1"> Option 1</label></li>
+		<li><label><input name="rg2_2" type="radio" value="0" checked> Three states</label></li>
+		<li><label><input name="rg2_2" type="radio" value="1"> Option 1</label></li>
+		<li><label><input name="rg2_2" type="radio" value="2"
+			data-icon="minus" data-color="warning" data-text="Nope"> Option 2</label></li>
+		<li><label><input name="rg2_3" type="radio" value="0" checked> Four states</label></li>
+		<li><label><input name="rg2_3" type="radio" value="1"> Option 1</label></li>
+		<li><label><input name="rg2_3" type="radio" value="2"> Option 2</label></li>
+		<li><label><input name="rg2_3" type="radio" value="3"> Option 2</label></li>
+	</ul>
+
+	<script>
+		$('#ex2').replaceCheckboxesWithButtons({
+			onicon: 'ok',
+		});
+	</script>
+	<br><br>
+
+
+
+
+	<h1>Multi-state-buttons</h1>
+
+	<h3>Single-icon</h3>
+
+	<h4>Example 3: makeMultiStateButton</h4>
+
+	<button class="mltsb-single-icon mltsb-3-stage" id="ex3_1">
+		Click me to change state!</button>
+	<button class="mltsb-single-icon mltsb-2-stage">Click me to change state!</button>
+
+	<script>
+		$('#ex3_1').makeMultiStateButton({
+			num_of_states: 3,
+			multi_icon: false,
+		})
+		$('button.mltsb-single-icon.mltsb-2-stage').makeMultiStateButton({
+			multi_icon: false,
+		})
+	</script>
+	<br><br>
+
+
+	<h4>Example 4: replaceInputsWithMultiStateButtons</h4>
+
+	<label for="ex4_1">From dropdowns:</label><br>
+	<p id="ex4_1">
+		<select>
+			<option value="">I have two states</option>
+			<option value="a">Option A</option>
+		</select>
+		<select>
+			<option value="">I have three states</option>
+			<option value="a">Option B</option>
+			<option value="b">Option C</option>
+		</select>
+		<select>
+			<option value="">I have three states, too</option>
+			<option value="a">Option D</option>
+			<option value="b">Option E</option>
+		</select>
+	</p><br>
+
+	<label for="ex4_2">From checkboxes and radio buttons:</label><br>
+	<ul id="ex4_2">
+		<li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+		<li><label><input name="rg4_1" type="radio" value="0" checked> State 0</label></li>
+		<li><label><input name="rg4_1" type="radio" value="1"> State 1</label></li>
+		<li><label><input name="rg4_1" type="radio" value="2"> State 2</label></li>
+		<li><label><input name="options" type="checkbox" value="2"> Option 2</label></li>
+		<li><label><input name="rg4_2" type="radio" value="0"> State 0</label></li>
+		<li><label><input name="rg4_2" type="radio" value="1" checked> State 1</label></li>
+		<li><label><input name="rg4_2" type="radio" value="2"> State 2</label></li>
+	</ul>
+
+	<script>
+		$('#ex4_1, #ex4_2').replaceInputsWithMultiStateButtons();
+	</script>
+	<br><br>
+
+
+	<h4>Example 5: Overriding</h4>
+
+	<label for="ex5_1">Options:</label>
+	<ul id="ex5_1">
+		<li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+		<li><label><input name="rg5_1" type="radio" value="0" checked> State 0</label></li>
+		<li><label><input name="rg5_1" type="radio" value="1"> State 1</label></li>
+		<li><label><input name="rg5_1" type="radio" value="2"> State 2</label></li>
+	</ul><br>
+
+	<label for="ex5_2">And data:</label>
+	<ul id="ex5_2">
+		<li><label>
+			<input name="options" type="checkbox" value="0"
+				data-off-text="Not selected"
+				data-on-color="primary" data-on-text="Selected" data-on-icon="check">
+				Option 0
+		</label></li>
+
+		<li><label>
+			<input name="options" type="checkbox" value="2"
+				data-off-color="info" data-off-icon="star-empty" data-on-icon="star">
+			Option 2
+		</label></li>
+
+		<li><label>
+			<input name="rg5_2" type="radio" value="0" checked> State 0
+		</label></li>
+		<li><label>
+			<input name="rg5_2" type="radio" value="1"> State 1
+		</label></li>
+		<li><label>
+			<input name="rg5_2" type="radio" value="2">
+			State 2
+		</label></li>
+
+		<li><label>
+			<input name="rg5_3" type="radio" value="0" checked> State 0
+		</label></li>
+		<li><label>
+			<input name="rg5_3" type="radio" value="1" data-icon="ok"> State 1
+		</label></li>
+		<li><label>
+			<input name="rg5_3" type="radio" value="2" data-color="info"> State 2
+		</label></li>
+	</ul><br>
+
+
+	<label for="ex5_3">Dropdowns:</label>
+	<p id="ex5_3">
+		<select>
+			<option value="">I have three states</option>
+			<option value="a">Option B</option>
+			<option value="b">Option C</option>
+		</select>
+		<select>
+			<option value="a">I have three states</option>
+			<option value="b" data-icon="ok">Option B</option>
+			<option value="c" data-icon="remove" data-color="danger">Option C</option>
+		</select>
+	</p>
+
+	<script>
+		$('#ex5_1, #ex5_2, #ex5_3').replaceInputsWithMultiStateButtons({
+			oncolor: 'danger', // applies only to checkboxes
+			color_1: 'success',
+			icon_1: 'plus',
+			color_2: 'warning',
+			icon_2: 'minus',
+		});
+	</script>
+	<br><br>
+
+	<h4>Example 6: Using label classes to replace</h4>
+	<label class="mltsb-label"><input name="options" type="checkbox" value="0"> Option 0</label>
+	<label class="mltsb-label"><input name="options" type="checkbox" value="1"> Option 1</label>
+	<label class="mltsb-label"><input name="options" type="checkbox" value="2"> Option 2</label>
+
+	<script>
+		$(".mltsb-label").replaceInputsWithMultiStateButtons()
+	</script>
+	<br><br><br>
+
+
+
+
+	<h3>Multi-icon</h3>
+
+	<h4>Example 7: makeMultiStateButton</h4>
+
+	<button class="mltsb-multi-icon mltsb-3-stage">Click me!</button>
+	<button id="ex7_2">Click me!</button>
+
+	<script>
+		$('button.mltsb-multi-icon.mltsb-3-stage').makeMultiStateButton({
+			num_of_states: 3,
+			multi_icon: true,
+			text_0: 'Option 0',
+			text_1: 'Option 1',
+			text_2: 'Option 2',
+		})
+		$('#ex7_2').makeMultiStateButton({
+			// num_of_states: 2,
+			multi_icon: true,
+			icon_on_0: 'question-sign',
+			icon_off_0: 'ban-circle',
+			// icon_on_0: 'ok-sign',
+			icon_off_1: 'ok-circle',
+			text_0: 'Option 0',
+			color_1: 'info',
+			text_1: 'Option 1',
+		})
+	</script>
+	<br><br>
+
+
+	<h4>Example 8: replaceInputsWithMultiStateButtons</h4>
+
+	<label for="ex8_1">Buttons from dropdowns:</label>
+	<p id="ex8_1">
+		<select>
+			<option value="">Default</option>
+			<option value="a">Option A</option>
+			<option value="b">Option B</option>
+		</select>
+		<select>
+			<option value="">Default</option>
+			<option value="c">Option C</option>
+		</select>
+	</p><br>
+
+	<label for="ex8_2">Different group of buttons from dropdowns:</label>
+	<p id="ex8_2">
+		<select>
+			<option value="">Default</option>
+			<option value="d">Option D</option>
+			<option value="e">Option E</option>
+		</select>
+	</p><br>
+
+	<label for="ex8_3">Checkbox and radio buttons:</label>
+	<ul id="ex8_3">
+		<li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+		<li><label><input name="rg8_1" type="radio" value="0" checked> State 0</label></li>
+		<li><label><input name="rg8_1" type="radio" value="1"> State 1</label></li>
+		<li><label><input name="rg8_1" type="radio" value="2"> State 2</label></li>
+		<li><label><input name="rg8_2" type="radio" value="0" checked> State 0</label></li>
+		<li><label><input name="rg8_2" type="radio" value="1"> State 1</label></li>
+	</ul><br>
+
+	<script>
+		$('#ex8_1, #ex8_2, #ex8_3').replaceInputsWithMultiStateButtons({
+			multi_icon: true,
+			// icon_on_0: 'minus-sign',  // you can try these settings as well
+			// icon_off_0: 'record',
+			// icon_on_1: 'ok-sign',
+			// icon_off_1: 'ok-circle',
+			// icon_on_2: 'remove-sign',
+			// icon_off_2: 'remove-circle',
+		});
+	</script>
+	<br>
+
+
+	<h4>Example 9: Overriding</h4>
+
+	<label for="ex9">Do you like:</label><br>
+	<p id="ex9">
+		<select>
+			<option value="">Ice cream?</option>
+			<option value="y">Yeah, I like ice cream</option>
+			<option value="s">Somewhat</option>
+			<option value="n">No</option>
+		</select>
+		<select>
+			<option value="">Chocolate?</option>
+			<option value="y">I love chocolate!</option>
+			<option value="s">Sure</option>
+			<option value="n">Not really</option>
+		</select>
+		<select>
+			<option value="c">Cookies?</option>
+			<option value="y" data-color="danger" data-icon-on="heart">I adore cookies!</option>
+			<option value="n"
+				data-icon-on="fire" data-icon-off="remove-circle" data-text="I hate them">No
+			</option>
+		</select>
+		<select data-icon-off="menu-right" data-icon-on="triangle-right">
+			<option value="">Custard?</option>
+			<option value="y" data-color="success">Yep!</option>
+			<option value="s" data-text="What's that?">What's that?</option>
+			<option value="dw" data-icon-on="sunglasses" data-color="primary">
+				Especially with fish fingers</option>
+		</select>
+	</p>
+
+	<script>
+		$('#ex9').replaceInputsWithMultiStateButtons({
+			multi_icon: true,
+			icon_on_0: 'question-sign',	// solid circled question mark
+			icon_off_0: 'ban-circle',
+			// icon_on_1: 'ok-sign'
+			icon_off_1: 'ok-circle',     // circled checkmark
+			icon_on_2: 'minus-sign',     // solid circled minus
+			// icon_off_2: 'record',
+			color_2: 'warning',          // yellow
+			text_2: 'Somewhat',          // all buttons will display 'Somewhat' on the third option
+			icon_on_3: 'remove-sign',    // solid circled X
+			icon_off_3: 'remove-circle', // regular circled X
+			color_3: 'danger',           // red
+		})
+	</script>
+	<br><br>
+
+	<h4>Example 10: Mixing single-icon and multi-icon buttons</h4>
+
+	<label for="ex10_1">Dropdowns:</label>
+	<p id="ex10_1">
+		<select data-type="single-icon">
+			<option value="">Default</option>
+			<option value="a">Option A</option>
+			<option value="b">Option B</option>
+		</select>
+		<select>
+			<option value="">Default</option>
+			<option value="c">Option C</option>
+		</select>
+		<select data-type="multi-icon"> <!-- Unnecessary -->
+			<option value="">Default</option>
+			<option value="d">Option D</option>
+			<option value="e">Option E</option>
+		</select>
+	</p><br>
+
+	<label for="ex10_2">Checkbox and radio buttons:</label>
+	<br>
+	<ul id="ex10_2">
+		<li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+		<li><label><input name="rg10_1" type="radio" value="0" checked> State 0</label></li>
+		<li><label><input name="rg10_1" type="radio" value="1"> State 1</label></li>
+		<li><label><input name="rg10_2" type="radio" value="0" checked> State 0</label></li>
+		<li><label><input name="rg10_2" type="radio" value="1"
+			data-type="single-icon"> State 1 <!-- any of the options can have the type -->
+		</label></li>
+		<li><label><input name="rg10_2" type="radio" value="2"> State 2</label></li>
+		<li><label>
+			<input name="rg10_3" type="radio" value="0" checked
+				data-type="single-icon"> State 0 <!-- overriden in latter option -->
+		</label></li>
+		<li><label><input name="rg10_3" type="radio" value="1"> State 1</label></li>
+		<li><label><input name="rg10_3" type="radio" value="2"
+			data-type="multi-icon"> State 2 <!-- last 'data-type' in radio group overrides -->
+		</label></li>
+	</ul>
+
+	<script>
+		$('#ex10_1, #ex10_2').replaceInputsWithMultiStateButtons({
+			multi_icon: true,
+			// icon_on_0: 'minus-sign', // you can try these settings as well
+			// icon_off_0: 'record',
+			// icon_on_1: 'ok-sign',
+			// icon_off_1: 'ok-circle',
+			// icon_on_2: 'remove-sign',
+			// icon_off_2: 'remove-circle',
+		});
+	</script>
+	<br><br><br>
+
+	<h4>Example 11</h4>
+
+	<button id="crazy">Click me!</button>
+
+	<script>
+		const sentence = (" Don't make a button like this it's just stupid " +
+			"to have a button with so many states :(").split(' ');
+		const num_of_states = sentence.length;
+		var args = {
+			num_of_states: num_of_states,
+			multi_icon: true,
+			icon_on: 'check',
+			icon_off: 'unchecked',
+		}
+		for (var i = 0; i < num_of_states; i++) {
+			args['text_' + i] = sentence[i]
+		}
+		$('#crazy').makeMultiStateButton(args)
+	</script>
+	<br><br><br><br>
+
+
+</body>
+</html>

--- a/jquery-toggle.js
+++ b/jquery-toggle.js
@@ -1,144 +1,387 @@
 (function($) {
+
+	/* A wrapper function to support older versions */
+	/* jquery method to make button or button like element a toggle button */
+	$.fn.makeToggleButton = function(options) {
+		this.makeMultiStateButton({
+			num_of_states: 2,
+			state: options.active ? 1 : 0,
+			multi_icon: false,
+			icon_0: options.officon,
+			text_0: options.offtext,
+			color_0: options.offcolor,
+			icon_1: options.onicon,
+			text_1: options.ontext,
+			color_1: options.oncolor,
+			nocolor: options.nocolor,
+			clickHandler: options.clickHandler,
+		})
+	}
+
+	/* A wrapper function to support older versions */
+	/* jquery method to replace checkboxes or radio selection with toggle buttons */
+	$.fn.replaceCheckboxesWithButtons = function(options) {
+		this.replaceInputsWithMultiStateButtons(options)
+	}
+
+
+	/*
+	 * Helper function for expressing icons.
+	 * Supports Font Awesome (icon names start with 'fa') and
+	 * Bootstap glyphicons (provide names without 'glyphicon' -text)
+	 * Returns icon-html-element
+	 */
+	function html_icon(name) {
+		if (!name) return ''     // no name, something went wrong
+		else if (!name.startsWith('fa') && !name.startsWith('glyphicon')) {
+			name = 'glyphicon glyphicon-' + name
+		}
+		return '<i class="' + name + '"></i>'
+	}
+
+	/*Helper function, goes through options and sets min-width to widest*/
+	function update_width(html_button) {
+		const button = $(html_button)
+		const args = button.data('jquery_toggle_options');
+		const original_state = args.state;
+		const widths = [];
+		do {
+			widths.push(button.outerWidth());
+			button.click();
+		} while (args.state != original_state);
+		const max_width = Math.max(...widths);
+		button.css('min-width', max_width + 'px');
+	}
+
+
 	/*
 	 * bound handler for button on:state_change
 	 * updates the state of the button element (icons, text and color)
 	 */
-	function update_button_state(event, active) {
-		var button = $(this);
-		var args = button.data('toggle_button');
-		var act = args[active ? "on" : "off"];
-		var not = args[active ? "off" : "on"];
+	function update_mltsb_state(event, state) {
+		const button = $(this);
+		const args = button.data('jquery_toggle_options');
+		const num_of_states = args.num_of_states;
+		const prev_state = (state + num_of_states - 1) % num_of_states;
+		const act = args[state];
+		const prev = args[prev_state];
+		// never shrink buttons
+		button.css('min-width', button.css('width'));
 
-		args.active = active;
-		if (!args.nocolor)
-			button.removeClass(not.color).addClass(act.color);
-		if (active) button.addClass('active');
-		else button.removeClass('active');
-		button.html('<i class="' + act.icon + '"></i> ' + act.text);
+		args.state = state;
+		if (state == 1) button.addClass('active');
+		else if (state == 0) button.removeClass('active');
+		button.removeClass('mltsb-state-' + prev_state)
+			.addClass('mltsb-state-' + state);
+
+		const icon = (
+			args.multi_icon ? act.icon.map( function(i) {return html_icon(i)} ).join('')
+			: html_icon(act.icon)
+		);
+		if (!args.nocolor) {
+			button.removeClass(prev.color).addClass(act.color);
+		}
+		button.html(icon + " " + act.text);
 		button.trigger('blur');
 	}
 
 	/* bound handler for button on:click and on:toggle_state*/
-	function toggle_button_state(event) {
-		var button = $(this);
-		var args = button.data('toggle_button');
-		var active = !args.active;
-		button.triggerHandler('state_change', [active]);
-		return active;
+	function toggle_mltsb_state(event) {
+		const button = $(this);
+		const args = button.data('jquery_toggle_options');
+		const state = (args.state + 1) % args.num_of_states;
+		button.triggerHandler('state_change', [state]);
+		return state;
 	}
 
-	/* bound handler for button on:click when used for radio buttons */
-	function radio_button_click_handler(event) {
-		var button = $(this);
-		var input = button.data('input_element');
-		var container = input.data('container_element');
+	/* bound handler for button on:click when used for select-tags (dropdwns) */
+	function select_button_click_handler(event) {
+		const button = $(this);
+		const input = button.data('input_element');
 
-		input.prop('checked', true);
-		container.find('input:radio').each(function() {
-			var ipt = $(this);
-			var btn = ipt.data('button_element');
-			var active = ipt.is(':checked');
-			btn.triggerHandler('state_change', [active]);
-		});
+		const prev = input.children(':selected');
+		var active = prev.next();
+		if (!active.length) active = input.children(":first");
+		active.prop('selected', true);
+		const new_state = input.children().index(active);
+		button.triggerHandler('state_change', [new_state]);
 	}
 
 	/* bound handler for button on:click when used for checkbox buttons */
 	function checkbox_button_click_handler(event) {
-		var button = $(this);
-		var input = button.data('input_element');
+		const button = $(this);
+		const input = button.data('input_element');
 
-		var active = !input.is(':checked');
+		const active = !input.is(':checked');
 		input.prop('checked', active);
-		button.triggerHandler('state_change', [active]);
+		const state = active ? 1 : 0
+		button.triggerHandler('state_change', [state]);
+	}
+
+	/* bound handler for button on:click when used for radio buttons */
+	function radio_button_click_handler(event) {
+		const button = $(this);
+		const inputs = button.data('inputs');  // Array[HTMLElement]
+		const args = button.data('jquery_toggle_options');
+		const prev_state = inputs.findIndex(function (i) {
+			return i.checked
+		})
+		const new_state = (prev_state + 1) % args.num_of_states;
+		inputs[new_state].checked = true;
+		button.triggerHandler('state_change', [new_state]);
 	}
 
 
-	/* Default values for makeToggleButton, replaceCheckboxesWithButtons */
-	var default_toggle_options = {
-		active: false, // initial state
-		onicon: 'check',
-		oncolor: 'primary',
-		// ontext: element.text()
-		officon: 'unchecked',
-		offcolor: 'default',
-		// offtext: element.text()
-		nocolor: false,
-		clickHandler: toggle_button_state,
-	};
-	var default_checkboxes_options = {
+	const default_group_options = {
 		groupClass: 'btn-group',
-		buttonClass: 'btn',
-	};
+	} ;
 
-	/* jquery method to make button or button like element a toggle button */
-	$.fn.makeToggleButton = function(options) {
-		var settings = $.extend({}, default_toggle_options, options);
+	const default_multi_state_options = {
+		state: 0,
+		num_of_states: 2,
+		color_0: 'default',
+		color: ['primary', 'danger', 'warning', 'success', 'info'],
+		nocolor: false,
+		clickHandler: toggle_mltsb_state,
+		buttonClass: 'btn',
+	} ;
+
+	const default_single_icon_options = {
+		icon_0: 'unchecked',
+		icon_1: 'check',
+		icon_2: 'remove',
+	} ;
+
+	const bootstrap_multi_icon_options = {
+		icon_on: 'ok-sign',
+		icon_off: 'record',
+	} ;
+
+	const fa_multi_icon_options = {
+		icon_on: 'fas fa-circle',
+		icon_off: 'far fa-circle',
+	} ;
+
+
+	/* jquery method to make button or button-like element a multi-state-button */
+	$.fn.makeMultiStateButton = function(options) {
+
+		const icon_options = (
+			(!options.multi_icon) ? default_single_icon_options
+			: options.font_awesome ? fa_multi_icon_options
+			: bootstrap_multi_icon_options
+		)
+		const settings = $.extend({}, default_multi_state_options, icon_options, options);
 
 		this.each(function() {
-			var button = $(this);
-			var args = {
-				on: {
-					icon: 'glyphicon glyphicon-' + settings.onicon,
-					text: settings.ontext || button.text().trim(),
-					color: 'btn-' + settings.oncolor,
-				},
-				off: {
-					icon: 'glyphicon glyphicon-' + settings.officon,
-					text: settings.offtext || button.text().trim(),
-					color: 'btn-' + settings.offcolor,
-				},
-				active: settings.active || button.hasClass('active'),
-				nocolor: settings.nocolor,
-			};
-			button.data('toggle_button', args);
+			const button = $(this)
+				.addClass(settings.buttonClass)
+				.css('text-align', 'left');
+			const num_of_states = settings.num_of_states;
 
-			if (settings.clickHandler !== false)
+			const args = {
+				state: settings.state,
+				active: settings.state != 0,
+				num_of_states: num_of_states,
+				nocolor: settings.nocolor,
+				multi_icon: settings.multi_icon,
+			};
+			for (i = 0; i < num_of_states; i++) {
+				var icon;
+				if (settings.multi_icon) {
+					icon = [...Array(num_of_states).keys()].map(function(n) {
+						if (n == i) return settings['icon_on_' + n] || settings.icon_on;
+						else return settings['icon_off_' + n] || settings.icon_off;
+					});
+				} else {
+					icon = settings['icon_' + i] || ''
+				}
+				args[i] = {
+					icon: icon,
+					text: settings['text_' + i] || button.text().trim(),
+				};
+				if (!settings.nocolor) {
+					const color = settings['color_' + i] || settings.color[(i - 1) % settings.color.length];
+					args[i]['color'] = 'btn-' + color;
+				}
+			}
+			button.data('jquery_toggle_options', args);
+
+			if (settings.clickHandler !== false) {
 				button.on('click', settings.clickHandler);
-			button.on('state_change', update_button_state);
-			button.on('toggle_state', toggle_button_state);
+			}
+			button.on('state_change', update_mltsb_state);
+			button.on('toggle_state', toggle_mltsb_state);
 
 			// run the handler
-			button.triggerHandler('state_change', [args.active]);
-        });
-
-        return this;
-    };
-
-	/* jquery method to replace checkboxes or radio selection with toggle buttons */
-	$.fn.replaceCheckboxesWithButtons = function(options) {
-		var settings = $.extend({}, default_checkboxes_options, options);
-
-		this.each(function() {
-			var widget = $(this);
-			var group = $('<div></div>')
-				.addClass(settings.groupClass);
-			widget.after(group);
-			widget.find('input:input, input:radio').each(function() {
-				var input = $(this);
-				var button = $('<button type="button"></button>')
-					.addClass(settings.buttonClass)
-					.addClass(input.data('class'));
-				group.append(button);
-
-				button.makeToggleButton({
-					onicon: input.data('on-icon') || settings.onicon,
-					ontext: input.data('on-text') || settings.ontext || input.parent().text().trim(),
-					oncolor: input.data('on-color') || settings.oncolor || input.data('color'),
-					officon: input.data('off-icon') || settings.officon,
-					offtext: input.data('off-text') || settings.offtext || input.parent().text().trim(),
-					offcolor: input.data('off-color') || settings.offcolor,
-					nocolor: settings.nocolor,
-					clickHandler: input.is(":radio") ? radio_button_click_handler : checkbox_button_click_handler,
-					active: input.is(':checked'),
-				});
-				if (settings.buttonSetup) settings.buttonSetup(input, button, group);
-				button.data('input_element', input);
-				input.data('button_element', button);
-				input.data('container_element', widget);
-			});
-			widget.addClass('hidden');
+			button.triggerHandler('state_change', [args.state]);
 		});
 
 		return this;
 	};
+
+	/* jquery method to replace checkboxes + radiobuttons or dropdown selections
+	 * with multi-state-buttons */
+	$.fn.replaceInputsWithMultiStateButtons = function(options) {
+		var settings = $.extend({}, default_group_options, options);
+		const buttons_by_field = new Map();
+
+		this.each(function() {
+			const widget = $(this);
+			const radio_buttons = new Map()
+			const group = $('<div></div>')
+				.addClass(settings.groupClass);
+			widget.after(group);
+
+			// goes through group of checkboxes and radio buttons
+			if (widget.has('input:checkbox, input:radio').length) {
+				widget.find(':input').each(function() {
+					input = $(this);
+
+					if (this.type == 'checkbox') {
+						const button = $('<button type="button"></button>')
+							.addClass(input.data('class'));
+						group.append(button);
+						args = {
+							num_of_states: 2,
+							icon_0: this.dataset['offIcon'] || settings.officon || settings.icon_0,
+							text_0: this.dataset['offText'] || settings.offtext || settings.text_0 || this.parentNode.innerText.trim(),
+							icon_1: this.dataset['onIcon'] || settings.onicon || settings.icon_1,
+							text_1: this.dataset['onText'] || settings.ontext || settings.text_1 || this.parentNode.innerText.trim(),
+							state: this.checked ? 1 : 0,
+							nocolor: settings.nocolor,
+							multi_icon: false,
+							clickHandler: checkbox_button_click_handler,
+							buttonClass: settings.buttonClass,
+						};
+						if (!settings.nocolor) {
+							args['color_0'] = this.dataset['offColor'] || settings.offcolor || settings.color_0;
+							args['color_1'] = this.dataset['onColor'] || settings.oncolor || settings.color_1;
+						};
+						button.makeMultiStateButton(args);
+						if (settings.buttonSetup) settings.buttonSetup(input, button);
+						button.data('input_element', input);
+						input.data('button_element', button);
+					}
+
+					else if (this.type == 'radio') {
+						const name = this.name;
+						var button;
+						if (!radio_buttons.has(name)) {
+							button = $('<button type="button"></button>')
+								.addClass(input.data('class'));
+							group.append(button);
+							radio_buttons.set(name, button);
+							button.data('inputs', [this]);
+						} else {
+							button = radio_buttons.get(name);
+							button.data('inputs').push(this);
+						}
+						this.dataset['button_element'] = button;
+						const multi_icon = (
+							this.dataset['type'] == 'multi-icon' ? true
+							: this.dataset['type'] == 'single-icon' ? false
+							: undefined
+						);
+						if (multi_icon) button.data('multi-icon', true);
+						else if (multi_icon !== undefined) button.data('multi-icon', false);
+					}
+					// dropdowns within a group of checkboxes and radio buttons are ignored
+				})
+
+				// compiles buttons of all radio options
+				radio_buttons.forEach(function(button) {
+					const radio_inputs = button.data('inputs');  // Array[HTMLElement]
+					const num_of_states = radio_inputs.length;
+					var multi_icon = button.data('multi-icon');
+					if (multi_icon === undefined) multi_icon = settings.multi_icon;
+					if (multi_icon === undefined) multi_icon = num_of_states > 3;
+					var selected_state = radio_inputs.findIndex(function(ipt) {return ipt.checked});
+					if (selected_state == -1) selected_state = 0  // none were checked
+					const args = {
+							num_of_states: num_of_states,
+							state: selected_state,
+							multi_icon: multi_icon,
+							nocolor: settings.nocolor,
+							clickHandler: radio_button_click_handler,
+							buttonClass: settings.buttonClass,
+					};
+					radio_inputs.forEach(function(input, i) {
+						args['text_' + i] = input.dataset['text'] || settings['text_' + i] || input.parentNode.innerText.trim();
+						if (multi_icon) {
+							args['icon_on_' + i] = input.dataset['iconOn'] || settings['icon_on_' + i];
+							args['icon_off_' + i] = input.dataset['iconOff'] || settings['icon_off_' + i];
+						} else {
+							args['icon_' + i] = input.dataset['icon'] || settings['icon_' + i];
+						}
+						if (!settings.nocolor) {
+							args['color_' + i] = input.dataset['color'] || settings['color_' + i];
+						}
+					})
+
+					button.makeMultiStateButton(args);
+					if (settings.buttonSetup) settings.buttonSetup(input, button);
+				})
+
+				widget.addClass('hidden');
+
+			// group of dropdowns
+			} else {
+				widget.find("select").each(function() {
+
+					const input = $(this)
+					const button = $('<button type="button"></button>')
+						.addClass(input.data('class'));
+					group.append(button)
+					const options = input.children()
+					const num_of_states = options.length
+					var multi_icon = (
+						this.dataset['type'] == 'multi-icon' ? true
+						: this.dataset['type'] == 'single-icon' ? false
+						: undefined
+					)
+					if (multi_icon === undefined) multi_icon = settings.multi_icon;
+					if (multi_icon === undefined) multi_icon = num_of_states > 3;
+					const icon_off = input.data('icon-off');
+					const icon_on = input.data('icon-on');
+
+					const args = {
+						num_of_states: num_of_states,
+						nocolor: settings.nocolor,
+						multi_icon: multi_icon,
+						clickHandler: select_button_click_handler,
+					}
+					const states = options.map(function(i) {
+						const elem_value = this.value
+						if (multi_icon) {
+							args['icon_on_' + i] = this.dataset['icon-on'] || icon_on || settings['icon_on_' + i];
+							args['icon_off_' + i] = this.dataset['icon-off'] || icon_off || settings['icon_off_' + i];
+						} else {
+							args['icon_' + i] = this.dataset['icon'] || settings['icon_' + i];
+						}
+						args['text_' + i] = this.dataset['text'] || settings['text_' + i] || this.text;
+						if (!settings.nocolor) {
+							args['color_' + i] = this.dataset['color'] || settings['color_' + i];
+						}
+						if (this.selected) {
+							args.state = i
+						}
+						return elem_value;
+					}).toArray();
+
+					button.makeMultiStateButton(args);
+					if (settings.buttonSetup) settings.buttonSetup(input, button);
+					button.data('input_element', input);
+					input.data('button_element', button);
+					input.parent().addClass('hidden');
+					update_width(button);
+				})
+			}
+
+		});
+
+		return this;
+	};
+
+
 }(jQuery));

--- a/multi_state_button_instructions.rst
+++ b/multi_state_button_instructions.rst
@@ -1,0 +1,287 @@
+##########################################
+Instructions for using multi-state-buttons
+##########################################
+
+replaceSelectWithMultiIconButtons
+==================================
+
+You can convert dropdowns to multi-state-buttons with the following code.
+The multi-state-buttons will be grouped by such that the dropdowns with
+the same label text will be grouped together under the same label.
+The button groups will appear at the location of the first dropdown with
+that label text. Dropdowns must be surrounded by a parent node, as that will
+be hidden.
+
+.. code-block:: html
+
+  <label for="dropdowns_1">Buttons:</label>
+  <p id="dropdowns_1">
+    <select>
+      <option value="">Default</option>
+      <option value="a">Option A</option>
+      <option value="b">Option B</option>
+    </select>
+    <select>
+      <option value="">Default</option>
+      <option value="c">Option C</option>
+    </select>
+  </p>
+  <label for="dropdowns_2">Different group of buttons:</label>
+  <p id="dropdowns_2">
+    <select>
+      <option value="">Default</option>
+      <option value="d">Option D</option>
+      <option value="e">Option E</option>
+    </select>
+  </p>
+
+.. code-block:: javascript
+
+  $('#button_1, #button_2, #button_3').replaceInputsWithMultiStateButtons();
+
+Another way to implement multi-state-buttons is with a list of checkboxes and
+radio buttons. Checkboxes will be replaced with single-icon two-state-buttons;
+radio groups are replaced with multi-state-buttons with each input represented
+by a state.
+
+.. code-block:: html
+
+  <label for="buttongroup_2">From checkboxes and radio buttons:</label><br>
+  <ul id="buttongroup_2">
+    <li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+    <li><label><input name="rg1" type="radio" value="0" checked> State 0</label></li>
+    <li><label><input name="rg1" type="radio" value="2"> State 2</label></li>
+    <li><label><input name="rg2" type="radio" value="0" checked> State 0</label></li>
+    <li><label><input name="rg2" type="radio" value="1"> State 1</label></li>
+    <li><label><input name="rg2" type="radio" value="2"> State 2</label></li>
+  </ul>
+
+.. code-block:: javascript
+
+  $('#buttongroup_2').replaceInputsWithMultiStateButtons();
+
+Default options and overriding
+------------------------------
+
+By default, if there are three or less states, a single-icon-button is used,
+and for four or more, a multi-icon-button is used. This can be overriden
+(however, checkboxes are always displayed as single-icon-buttons).
+
+The default single-icon-button icons are the following:
+
+=====   ================    ==============
+State   Icon                Bootstrap name
+=====   ================    ==============
+0       empty checkbox      unchecked
+1       checked checkbox    check
+2       X                   remove
+=====   ================    ==============
+
+There are two sets of default icons for the multi-icon-buttons,
+ones using Bootstrap glyphicons and another using Font Awesome icons.
+The Bootstrap set is used by default, but if there is access to the
+Font Awesome library, the Font Awesome icons can be used by providing
+:code:`font_awesome: true` as one of the key-value pairs of the
+argument object of the method :code:`replaceInputsWithMultiStateButtons`.
+
++------------+-------------------+--------------+--------------+---------------+
+|            | Bootstrap                        | Font Awesome                 |
++            +-------------------+--------------+--------------+---------------+
+|            | Icon              | Name         | Icon         |  Name         |
++============+===================+==============+==============+===============+
+| icon_on    | ✓ in solid circle | check-sign   | solid circle | fas fa-circle |
++------------+-------------------+--------------+--------------+---------------+
+| icon_off   | circled dot       | record       | empty circle | far fa-circle |
++------------+-------------------+--------------+--------------+---------------+
+
+Font Awesome icons must be referred to by their full name (beginning with
+'far fa-', 'fas fa-' or 'fal-fa'), but Bootstrap glyphs can be named
+without 'glyphicon glyphicon-'.
+
+The possible colors of the buttons are Bootstrap colors:
+
+=======  ===========
+Name     Color
+=======  ===========
+default  white
+primary  bright blue
+danger   red
+warning  yellow
+success  green
+info     light blue
+=======  ===========
+
+In addition to these characteristics, there is an optional characteristic
+:code:`text` for each option.
+This is the text displayed on the button when that option is selected.
+If :code:`text` is not defined, the text of the option (as displayed in the
+dropdown, radio button or checkbox) will be displayed.
+
+On multi-icon buttons, if the button has :code:`n` options, the button will
+display :code:`n` icons, one for each option (in order). The icon of the
+currently selected option will be the icon specified by the on-icon parameter
+of that option, the rest will be off-icons of the other options respectively.
+
+
+**General parameters**
+
+state : Int
+  The state the buttons begin with (default 0)
+multi_icon: Boolean
+  If set to true, displays an icon for each option on the button at all times.
+  If set to false, displayes a single icon on the button at all times.
+  If not set, uses false (singe-icon) if there are at most 3 states and true
+  (multi-icon) if there are at least 4 states.
+icon_off: String   (multi-icon)
+  The icon displayed for a not-selected option if a specific icon is not defined
+  for that option.
+  Defaults: circled dot (Bootstrap), empty circle (Font Awesome)
+icon_on: String   (multi-icon)
+  The icon displayed for a selected option if a specific icon is not defined
+  for that option.
+  Defaults: check mark within a solid circle (Bootrap),
+  solid circle (Font Awesome)
+nocolor : Boolean
+  If set to true, the buttons will stay white despite the state.
+  If set to false (default), buttons will change color according to state.
+font_awesome : Boolean
+  Whether to use Font Awesome icons in default set or not.
+  If set to true, uses default set consisting of Font Awesome icons.
+  If set to false (default), uses default set consisting of Bootstrap icons.
+buttonClass : String
+  One or more space-separated classes to be added to the class attributes of
+  the buttons. By default uses :code:`'btn'`, which means the button is
+  displayed as a Bootstrap button. (To prevent that, provide an empty string
+  or any string as the value of this key.)
+
+**Parameters of each option/state**
+*In the parameter names,* :code:`i` *is replaced by the index of the option.
+Eg.* :code:`icon_on_0` *and* :code:`color_1`
+
+icon_i : String   (single-icon)
+  The only icon displayed on the button when this option/state is selected.
+icon_on_i : String   (multi-icon)
+  Icon displayed among other icons when this option/state is selected.
+  If not provided, uses the general :code:`icon_on`.
+icon_off_i : String   (multi-icon)
+  Icon displayed among other icons when this option/state is not selected.
+  If not provided, uses the general :code:`icon_off`.
+color_i : String
+  The color of the button when this option/state is selected.
+  If not provided, uses the color default for the first state and
+  the color in the table of the index :code:`[(i-1 % 5) + 1]`
+  (loops through the last five colors).
+text_i : String
+  The text displayed on the button when this option/state is selected.
+  If not provided, uses the text of the option in the dropdown, or the text of
+  the checkbox or radio button.
+
+
+
+Overriding with arguments
+.........................
+
+Any of the characteristics (icon / on-icon / off-icon, color, text) of an option can be
+overriden.
+
+.. code-block:: html
+
+<label for="ex9_1">Do you like:</label><br>
+  <p id="ex9_1">
+    <select>
+      <option value="">Ice cream?</option>
+      <option value="y">Yeah, I like ice cream</option>
+      <option value="s">Somewhat</option>
+      <option value="n">No</option>
+    </select>
+    <select>
+      <option value="">Chocolate?</option>
+      <option value="y">I love chocolate!</option>
+      <option value="s">Sure</option>
+      <option value="n">Not really</option>
+    </select>
+  </p>
+
+.. code-block:: javascript
+
+  $('#ex9_1').replaceInputsWithMultiStateButtons({
+    multi_icon: true,
+    icon_on_0: 'question-sign',  // solid circled question mark
+    icon_off_0: 'ban-circle',
+    // icon_on_1: 'ok-sign'
+    icon_off_1: 'ok-circle',     // circled checkmark
+    icon_on_2: 'minus-sign',     // solid circled minus
+    // icon_off_2: 'record',
+    color_2: 'warning',          // yellow
+    text_2: 'Somewhat',          // all buttons will display 'Somewhat' on the third option
+    icon_on_3: 'remove-sign',    // solid circled X
+    icon_off_3: 'remove-circle', // regular circled X
+    color_3: 'danger',           // red
+  })
+
+
+Overriding with data
+....................
+
+The characteristics of the options/states can also be overriden individually
+for a button through the data attribute. These override the argument overrides.
+
++-------------+-----------------+-------------+------------+-----------+----------------+---------------------------+
+| Data        | Possible values | Single-icon | Multi-icon | Checkbox  | Radio button   | Dropdown (select)         |
++=============+=================+=============+============+===========+================+===========================+
+| officon     | Bootstrap       | X           | \-         | input-tag | \-             | \-                        |
++             + icon names      +             +            +           +                +                           +
+| onicon      | (with or        |             |            |           |                |                           |
++-------------+ without         +-------------+------------+-----------+----------------+---------------------------+
+| icon        | "glyphicon"     | X           | \-         | \-        | input-tag      | option-tag                |
++-------------+ text),          +-------------+------------+-----------+----------------+---------------------------+
+| icon-off    | Font            | \-          | X          | \-        | input-tag      | select-tag (general, all) |
++             + Awesome         +             +            +           +                +                           +
+| icon-on     | icon names      |             |            |           |                | option-tag (each option)  |
++-------------+-----------------+-------------+------------+-----------+----------------+---------------------------+
+| offcolor    | Bootstrap       | X           |            | input-tag | \-             | \-                        |
++             + colors          +             +            +           +                +                           +
+| oncolor     | (see            |             |            |           |                |                           |
++-------------+ list            +-------------+------------+-----------+----------------+---------------------------+
+| color       | above)          | X           | X          | \-        | input-tag      | option-tag                |
++-------------+-----------------+-------------+------------+-----------+----------------+---------------------------+
+| offtext     | Any string      | X           | \-         | input-tag | \-             | \-                        |
++             +                 +             +            +           +                +                           +
+| ontext      |                 |             |            |           |                |                           |
++-------------+                 +-------------+------------+-----------+----------------+---------------------------+
+| text        |                 | X           | X          | \-        | input-tag      | option-tag                |
++-------------+-----------------+-------------+------------+-----------+----------------+---------------------------+
+| type        | "single-icon",  |             |            | \-        | input-tag      | select-tag                |
+|             | "multi-icon"    |             |            |           | (last instance |                           |
+|             |                 |             |            |           | overrides      |                           |
+|             |                 |             |            |           | earlier ones)  |                           |
++-------------+-----------------+-------------+------------+-----------+----------------+---------------------------+
+
+.. code-block:: html
+
+  <p id="ex9_2">
+    <select>
+      <option value="c">Cookies?</option>
+      <option value="y" data-color="danger" data-icon-on="heart">I adore cookies!</option>
+      <option value="n"
+        data-icon-on="fire" data-icon-off="remove-circle" data-text="I hate them">No
+      </option>
+    </select>
+    <select data-icon-off="menu-right" data-icon-on="triangle-right">
+      <option value="">Custard?</option>
+      <option value="y" data-color="success">Yep!</option>
+      <option value="s" data-text="What's that?">What's that?</option>
+      <option value="dw" data-icon-on="sunglasses" data-color="primary">
+        Especially with fish fingers</option>
+    </select>
+  </p>
+
+.. code-block:: javascript
+
+  $('#ex9_2').replaceSelectWithMultiStateButtons({
+    multi_icon: true,
+    icon_on_0: 'question-sign',
+    icon_off_0: 'ban-circle',
+    icon_off_1: 'ok-circle',
+    color_2: 'warning',
+  });


### PR DESCRIPTION
Add support for replacing checkboxes, radio groups and dropdowns
with multi-state-buttons. Script supports both single-icon- and
multi-icon-buttons. Add documentation and instructions for new
methods; add examples to demonstrate usage.