### PR TITLE
Add indentation missing from code block

### DIFF
--- a/multi_state_button_instructions.rst
+++ b/multi_state_button_instructions.rst
@@ -186,7 +186,7 @@ overriden.
 
 .. code-block:: html
 
-<label for="ex9_1">Do you like:</label><br>
+  <label for="ex9_1">Do you like:</label><br>
   <p id="ex9_1">
     <select>
       <option value="">Ice cream?</option>


### PR DESCRIPTION
# Description

Add missing indentation, the lack of which had broken a code block in the documentation.

# Testing

Tested manually, that block works now.

# Have you updated the README or other relevant documentation?

Not relevant

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] ~I (developer) have created unit tests and the tests pass~
- [ ] ~I (developer) have created functional tests (Selenium tests) if applicable~
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
