### PR TITLE
Fix event triggerings and data attribute name formattings

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -403,8 +403,51 @@
 		}
 		$('#crazy').makeMultiStateButton(args)
 	</script>
-	<br><br><br><br>
+	<br><br><br>
 
+	<h3>Triggering change events</h3>
+
+	<h4>Example 12: With event listeners and onchange functions</h4>
+
+	<label for="ex12_1">From dropdowns:</label><br>
+	<p id="ex12_1">
+		<select>
+			<option value="">I have two states</option>
+			<option value="a">Option A</option>
+		</select>
+		<select onchange="document.getElementById('ex12_event_log2').textContent = this.value">
+			<option value="">I have three states</option>
+			<option value="a">Option B</option>
+			<option value="b">Option C</option>
+		</select>
+	</p><br>
+
+	<label for="ex12_2">From checkboxes and radio buttons:</label><br>
+	<ul id="ex12_2">
+		<li><label><input name="options" type="checkbox" value="0"> Option 0</label></li>
+		<li><label><input name="rg4_1" type="radio" value="0" checked> State 0</label></li>
+		<li><label><input name="rg4_1" type="radio" value="1"> State 1</label></li>
+		<li><label><input name="rg4_1" type="radio" value="2"> State 2</label></li>
+	</ul>
+
+	<br><br>
+	<p>
+		<b>Number of changes:</b> <span id="ex12_event_log1">0</span>
+	</p>
+	<p>
+		<b>Value of second dropwdown:</b> <span id="ex12_event_log2"></span>
+	</p>
+
+	<script>
+		$('#ex12_1, #ex12_2').replaceInputsWithMultiStateButtons();
+		$('#ex12_1 select, #ex12_2 :checkbox, #ex12_2 :radio').each(function(i, elem) {
+			elem.addEventListener('change', function(evt) {
+				const evtLog = document.getElementById("ex12_event_log1");
+				evtLog.textContent = Number(evtLog.textContent) + 1
+			});
+		})
+	</script>
+	<br><br>
 
 </body>
 </html>

--- a/jquery-toggle.js
+++ b/jquery-toggle.js
@@ -279,12 +279,12 @@
 						}
 						this.dataset['button_element'] = button;
 						const multi_icon = (
-							this.dataset['type'] == 'multi-icon' ? true
-							: this.dataset['type'] == 'single-icon' ? false
+							this.dataset['type'] == 'multiIcon' ? true
+							: this.dataset['type'] == 'singleIcon' ? false
 							: undefined
 						);
-						if (multi_icon) button.data('multi-icon', true);
-						else if (multi_icon !== undefined) button.data('multi-icon', false);
+						if (multi_icon) button.data('multiIcon', true);
+						else if (multi_icon !== undefined) button.data('multiIcon', false);
 					}
 					// dropdowns within a group of checkboxes and radio buttons are ignored
 				})
@@ -293,7 +293,7 @@
 				radio_buttons.forEach(function(button) {
 					const radio_inputs = button.data('inputs');  // Array[HTMLElement]
 					const num_of_states = radio_inputs.length;
-					var multi_icon = button.data('multi-icon');
+					var multi_icon = button.data('multiIcon');
 					if (multi_icon === undefined) multi_icon = settings.multi_icon;
 					if (multi_icon === undefined) multi_icon = num_of_states > 3;
 					var selected_state = radio_inputs.findIndex(function(ipt) {return ipt.checked});
@@ -336,14 +336,14 @@
 					const options = input.children()
 					const num_of_states = options.length
 					var multi_icon = (
-						this.dataset['type'] == 'multi-icon' ? true
-						: this.dataset['type'] == 'single-icon' ? false
+						this.dataset['type'] == 'multiIcon' ? true
+						: this.dataset['type'] == 'singleIcon' ? false
 						: undefined
 					)
 					if (multi_icon === undefined) multi_icon = settings.multi_icon;
 					if (multi_icon === undefined) multi_icon = num_of_states > 3;
-					const icon_off = input.data('icon-off');
-					const icon_on = input.data('icon-on');
+					const icon_off = input.data('iconOff');
+					const icon_on = input.data('iconOn');
 
 					const args = {
 						num_of_states: num_of_states,
@@ -354,8 +354,8 @@
 					const states = options.map(function(i) {
 						const elem_value = this.value
 						if (multi_icon) {
-							args['icon_on_' + i] = this.dataset['icon-on'] || icon_on || settings['icon_on_' + i];
-							args['icon_off_' + i] = this.dataset['icon-off'] || icon_off || settings['icon_off_' + i];
+							args['icon_on_' + i] = this.dataset['iconOn'] || icon_on || settings['icon_on_' + i];
+							args['icon_off_' + i] = this.dataset['iconOff'] || icon_off || settings['icon_off_' + i];
 						} else {
 							args['icon_' + i] = this.dataset['icon'] || settings['icon_' + i];
 						}

--- a/jquery-toggle.js
+++ b/jquery-toggle.js
@@ -53,6 +53,24 @@
 		button.css('min-width', max_width + 'px');
 	}
 
+	/*
+	 * Helper function to dispatch change event.
+	 * jQuery event triggers alert only jQuery event listeners, not native ones.
+	 */
+	function simulateChange(elem) {
+		let event;
+		if (typeof Event === 'function') {
+			event = new Event('change', {
+				bubbles: true,
+				cancelable: false,
+			});
+		} else { // IE11
+			event = document.createEvent('Event');
+			event.initEvent('change', true, false);
+		}
+		elem.dispatchEvent(event);
+	}
+
 
 	/*
 	 * bound handler for button on:state_change
@@ -82,7 +100,6 @@
 			button.removeClass(prev.color).addClass(act.color);
 		}
 		button.html(icon + " " + act.text);
-		button.trigger('blur');
 	}
 
 	/* bound handler for button on:click and on:toggle_state*/
@@ -103,6 +120,9 @@
 		var active = prev.next();
 		if (!active.length) active = input.children(":first");
 		active.prop('selected', true);
+		active.each(function(i, elem) {
+			simulateChange(elem)
+		});
 		const new_state = input.children().index(active);
 		button.triggerHandler('state_change', [new_state]);
 	}
@@ -114,6 +134,9 @@
 
 		const active = !input.is(':checked');
 		input.prop('checked', active);
+		input.each(function (i, elem) {
+			simulateChange(elem)
+		});
 		const state = active ? 1 : 0
 		button.triggerHandler('state_change', [state]);
 	}
@@ -128,6 +151,7 @@
 		})
 		const new_state = (prev_state + 1) % args.num_of_states;
 		inputs[new_state].checked = true;
+		simulateChange(inputs[new_state]);
 		button.triggerHandler('state_change', [new_state]);
 	}
 


### PR DESCRIPTION
# Description

When the states of the checkboxes, radio buttons, and dropdowns were changed, the `change` event wasn't fired which could cause problems with event listeners.
Also buttons were unfocused on click, which meant that navigating the multi-state buttons via keyboard was problematic.

Overriding didn't work quite as it was supposed to due to assumption of dash-usage, which is converted to camelCase through the `dataset` object. Thus the keys are changed to camelCase as well.

# Testing

No unit tests.

I manually tested that the buttons work as wished by playing around with the examples file and by adding event listeners as well as `onchange` functions. I also added an example to the `examples.html` file which allows for testing that the `change` events are dispatched properly.

# Have you updated the README or other relevant documentation?

I didn't update the documentation since its probably assumed that a `change` event is fired on the change of state, but I did update the `examples.html` file which strongly supports the documentation.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
